### PR TITLE
CLI - Add auth, headers & timeout flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,9 +29,9 @@ Check CLI usage
 
 ```
 ❯ csv2http --help
-usage: csv2http [-h] [-c CONCURRENCY] [--method {POST,PATCH,PUT}] [-d] [-n] file url
+usage: csv2http [-h] [-c CONCURRENCY] [--method {POST,PATCH,PUT}] [-a AUTH] [-H [HEADER ...]] [-d] [-n] [-t TIMEOUT] file url
 
-HTTP request for every row of a CSV file - v0.0.2a
+HTTP request for every row of a CSV file - v0.0.3a
 
 positional arguments:
   file                  payload csv file
@@ -43,8 +43,13 @@ options:
                         Maximum number of concurrent requests (default: 25)
   --method {POST,PATCH,PUT}
                         HTTP method/verb (default: POST)
+  -a AUTH, --auth AUTH  Basic Authentication enter <USERNAME>:<PASSWORD>. If password is blank you will be prompted for input
+  -H [HEADER ...], --header [HEADER ...]
+                        Header `key:value` pairs
   -d, --form-data       Send payload as form encoded data instead of JSON (default: false)
   -n, --no-save         Do not save results to log file (default: false)
+  -t TIMEOUT, --timeout TIMEOUT
+                        Connection timeout of the request in seconds (default: 10)
 ```
 
 ### Mockbin Example
@@ -74,6 +79,28 @@ Use the returned bin id from before.
 
 Check the bin log from.
 https://mockbin.org/bin/9e95289e-d048-4515-9a61-07f2c74810f5/log
+
+### Set Auth and Headers
+
+Header key, value pairs can be set with the `-H` or `-header` flag.
+
+Key value pairs should be separated with either a `:` or `=`.
+
+```
+csv2http my_file.csv httpbin.org/post -H user-agent:csv2http-cli x-custom-header=foobar
+```
+
+To provide basic auth pass a username and password with `-a` or `--auth`.
+
+If the password is omitted you will be prompted to provide it.
+
+```
+--auth my_username:my_password
+```
+
+```
+--auth my_username
+```
 
 ## Roadmap
 

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ options:
   -d, --form-data       Send payload as form encoded data instead of JSON (default: false)
   -n, --no-save         Do not save results to log file (default: false)
   -t TIMEOUT, --timeout TIMEOUT
-                        Connection timeout of the request in seconds (default: 10)
+                        Connection timeout of the request in seconds (default: 5)
 ```
 
 ### Mockbin Example

--- a/csv2http/_version.py
+++ b/csv2http/_version.py
@@ -1,2 +1,2 @@
 """_version"""
-__version__ = "0.0.2a1"
+__version__ = "0.0.3a"

--- a/csv2http/cli.py
+++ b/csv2http/cli.py
@@ -15,6 +15,10 @@ SUPPORTED_METHODS = ["POST", "PATCH", "PUT"]
 CONCURRENCY_DEFAULT = 25
 
 
+def _get_input(prompt: str):
+    return input(prompt)
+
+
 def _normalize_url(value: Union[str, URL]) -> URL:
     """Add scheme to url string if it's missing."""
     url = URL(value)
@@ -27,7 +31,7 @@ def _resolve_auth(value: str) -> Union[tuple[str, str], tuple[None, None]]:
     """Parse username & password. Prompt for password if not provided."""
     user_name, password = value.split(" ", maxsplit=1)
     if user_name and not password:
-        password = input("password")
+        password = _get_input("password")
     return user_name, password
 
 

--- a/csv2http/cli.py
+++ b/csv2http/cli.py
@@ -32,10 +32,8 @@ def _normalize_url(value: Union[str, URL]) -> URL:
 def _resolve_auth(value: str) -> Union[tuple[str, str], tuple[None, None]]:
     """
     Parse username & password. Prompt for password if not provided.
-    Only splits on `:` to avoid issues with Base64 encoded strings.
     """
-    # username, *extras = re.split(_SPLIT_REGEX, value, maxsplit=1)
-    username, *extras = value.split(":", maxsplit=1)
+    username, *extras = re.split(_SPLIT_REGEX, value, maxsplit=1)
     if extras:
         password = " ".join(extras)
     else:

--- a/csv2http/cli.py
+++ b/csv2http/cli.py
@@ -35,10 +35,7 @@ def _resolve_auth(value: str) -> Union[tuple[str, str], tuple[None, None]]:
     Parse username & password. Prompt for password if not provided.
     """
     username, *extras = re.split(_SPLIT_REGEX, value, maxsplit=1)
-    if extras:
-        password = " ".join(extras)
-    else:
-        password = _get_input("password:")
+    password = " ".join(extras) if extras else _get_input("password:")
     return username, password
 
 

--- a/csv2http/cli.py
+++ b/csv2http/cli.py
@@ -12,8 +12,9 @@ from httpx import URL, Headers
 from csv2http._version import __version__
 
 SUPPORTED_METHODS = ["POST", "PATCH", "PUT"]
-
 CONCURRENCY_DEFAULT = 25
+
+_SPLIT_REGEX = r"[:=]"
 
 
 def _get_input(prompt: str):
@@ -29,18 +30,22 @@ def _normalize_url(value: Union[str, URL]) -> URL:
 
 
 def _resolve_auth(value: str) -> Union[tuple[str, str], tuple[None, None]]:
-    """Parse username & password. Prompt for password if not provided."""
-    username, *extras = value.split(" ", maxsplit=1)
+    """
+    Parse username & password. Prompt for password if not provided.
+    Only splits on `:` to avoid issues with Base64 encoded strings.
+    """
+    # username, *extras = re.split(_SPLIT_REGEX, value, maxsplit=1)
+    username, *extras = value.split(":", maxsplit=1)
     if extras:
         password = " ".join(extras)
     else:
-        password = _get_input("password")
+        password = _get_input("password:")
     return username, password
 
 
 def _parse_header(value: str) -> tuple[str, str]:
-    """Splits string on : = or whitespace and returns a dictionary"""
-    key, value = re.split(r"[:= ]", value, maxsplit=1)
+    """Splits string on `:` or `=` and returns a tuple of key, value."""
+    key, value = re.split(_SPLIT_REGEX, value, maxsplit=1)
     return key, value
 
 

--- a/csv2http/cli.py
+++ b/csv2http/cli.py
@@ -13,7 +13,7 @@ from csv2http._version import __version__
 
 SUPPORTED_METHODS = ["POST", "PATCH", "PUT"]
 CONCURRENCY_DEFAULT = 25
-TIMEOUT_DEFAULT = 10
+TIMEOUT_DEFAULT = 5
 
 _SPLIT_REGEX = r"[:=]"
 

--- a/csv2http/cli.py
+++ b/csv2http/cli.py
@@ -29,10 +29,12 @@ def _normalize_url(value: Union[str, URL]) -> URL:
 
 def _resolve_auth(value: str) -> Union[tuple[str, str], tuple[None, None]]:
     """Parse username & password. Prompt for password if not provided."""
-    user_name, password = value.split(" ", maxsplit=1)
-    if user_name and not password:
+    username, *extras = value.split(" ", maxsplit=1)
+    if extras:
+        password = " ".join(extras)
+    else:
         password = _get_input("password")
-    return user_name, password
+    return username, password
 
 
 class Args(NamedTuple):

--- a/csv2http/cli.py
+++ b/csv2http/cli.py
@@ -123,8 +123,8 @@ def get_args() -> Args:
         args.url,
         args.concurrency,
         args.method,
-        args.header,
         args.auth,
+        Headers(args.header),
         args.form_data,
         not args.no_save
         # args.verbose,

--- a/csv2http/cli.py
+++ b/csv2http/cli.py
@@ -13,6 +13,7 @@ from csv2http._version import __version__
 
 SUPPORTED_METHODS = ["POST", "PATCH", "PUT"]
 CONCURRENCY_DEFAULT = 25
+TIMEOUT_DEFAULT = 10
 
 _SPLIT_REGEX = r"[:=]"
 
@@ -73,11 +74,13 @@ def _bootstrap_parser() -> argparse.ArgumentParser:
     parser.add_argument(
         "-a",
         "--auth",
-        help="Basic Authentication enter <USERNAME> <PASSWORD>."
-        "If password is blank you will be prompted for input",
+        help="Basic Authentication enter <USERNAME>:<PASSWORD>."
+        " If password is blank you will be prompted for input",
         type=_resolve_auth,
     )
-    parser.add_argument("-H", "--header", nargs="*", type=_parse_header)
+    parser.add_argument(
+        "-H", "--header", help="Header `key:value` pairs", nargs="*", type=_parse_header
+    )
     parser.add_argument(
         "-d",
         "--form-data",
@@ -90,8 +93,18 @@ def _bootstrap_parser() -> argparse.ArgumentParser:
         help="Do not save results to log file (default: false)",
         action="store_true",
     )
+    parser.add_argument(
+        "-t",
+        "--timeout",
+        help=f"Connection timeout of each request in seconds (default: {TIMEOUT_DEFAULT})",
+        default=TIMEOUT_DEFAULT,
+        type=int,
+    )
     # parser.add_argument(
-    #     "-v", "--verbose", help="verbose stdout logging", default=False, type=bool
+    #     "-v",
+    #     "--verbose",
+    #     help="verbose stdout logging",
+    #     action="store_true",
     # )
     return parser
 
@@ -107,7 +120,8 @@ class Args(NamedTuple):
     headers: Optional[Headers] = None
     form_data: bool = False
     save_log: bool = True
-    # verbose: bool = True
+    timeout: int = TIMEOUT_DEFAULT
+    # verbose: bool = False
 
 
 _PARSER = _bootstrap_parser()
@@ -124,7 +138,8 @@ def get_args() -> Args:
         args.auth,
         Headers(args.header),
         args.form_data,
-        not args.no_save
+        not args.no_save,
+        args.timeout,
         # args.verbose,
     )
 

--- a/csv2http/core.py
+++ b/csv2http/core.py
@@ -93,7 +93,7 @@ async def execute(args: cli.Args) -> int:
     log_file = _add_timestamp_and_suffix(file_input, "log")
 
     async with httpx.AsyncClient(
-        auth=args.auth, headers=args.headers
+        auth=args.auth, headers=args.headers, timeout=args.timeout
     ) as client_session:
 
         print(f" {args.method} {args.url}")

--- a/csv2http/core.py
+++ b/csv2http/core.py
@@ -92,7 +92,9 @@ async def execute(args: cli.Args) -> int:
     content = "data" if args.form_data else "json"
     log_file = _add_timestamp_and_suffix(file_input, "log")
 
-    async with httpx.AsyncClient() as client_session:
+    async with httpx.AsyncClient(
+        auth=args.auth, headers=args.headers
+    ) as client_session:
 
         print(f" {args.method} {args.url}")
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,3 +1,5 @@
+import pathlib
+
 import pytest
 from httpx import URL
 
@@ -31,6 +33,43 @@ def test_resolve_auth(monkeypatch, auth_input, expected):
     monkeypatch.setattr(cli, "_get_input", lambda x: "fake_input", raising=True)
 
     assert expected == cli._resolve_auth(auth_input)
+
+
+@pytest.mark.parametrize(
+    "headers_input",
+    [
+        "foo:bar",
+        "foo=bar",
+        "foo bar",
+    ],
+)
+def test_pase_header(headers_input):
+
+    assert ("foo", "bar") == cli._parse_header(headers_input)
+
+
+@pytest.mark.parametrize(
+    "args,expected",
+    [
+        (
+            ["myfile.csv", "example.com"],
+            {
+                "auth": None,
+                "concurrency": cli.CONCURRENCY_DEFAULT,
+                "file": pathlib.Path("myfile.csv"),
+                "form_data": False,
+                "header": None,
+                "method": "POST",
+                "no_save": False,
+                "url": URL("https://example.com"),
+            },
+        )
+    ],
+)
+def test_get_args(args, expected):
+    parser = cli._bootstrap_parser()
+
+    assert expected == vars(parser.parse_args(args))
 
 
 if __name__ == "__main__":

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -16,5 +16,17 @@ def test_normalize_ulr(url, expected):
     assert URL(expected) == cli._normalize_url(url)
 
 
+@pytest.mark.parametrize(
+    "url,expected",
+    [
+        ("https://example.com", "https://example.com"),
+        ("example.com", "https://example.com"),
+        ("example.com/foo/bar", "https://example.com/foo/bar"),
+    ],
+)
+def test_resolve_auth(url, expected):
+    assert URL(expected) == cli._normalize_url(url)
+
+
 if __name__ == "__main__":
     pytest.main(["-vv"])

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -17,15 +17,18 @@ def test_normalize_ulr(url, expected):
 
 
 @pytest.mark.parametrize(
-    "url,expected",
+    "auth_input,expected",
     [
-        ("https://example.com", "https://example.com"),
-        ("example.com", "https://example.com"),
-        ("example.com/foo/bar", "https://example.com/foo/bar"),
+        ("foo bar", ("foo", "bar")),
+        # this probably invalid auth but not responsiblity of _resolve_auth
+        ("foo bar bazz", ("foo", "bar bazz")),
+        ("fizz", ("fizz", "fake_input")),
     ],
 )
-def test_resolve_auth(url, expected):
-    assert URL(expected) == cli._normalize_url(url)
+def test_resolve_auth(monkeypatch, auth_input, expected):
+    monkeypatch.setattr(cli, "_get_input", lambda x: "fake_input", raising=True)
+
+    assert expected == cli._resolve_auth(auth_input)
 
 
 if __name__ == "__main__":

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -43,6 +43,10 @@ def test_resolve_auth(monkeypatch, auth_input, expected):
         ("foo:bar", ("foo", "bar")),
         ("foo=bar", ("foo", "bar")),
         (
+            "Authorization=Bearer MY.JWT.TOKEN",
+            ("Authorization", "Bearer MY.JWT.TOKEN"),
+        ),
+        (
             # ensure base64 padding is not removed
             f"foo={base64.standard_b64encode(b'bar64').decode('utf-8')}",
             ("foo", base64.standard_b64encode(b"bar64").decode("utf-8")),
@@ -68,6 +72,7 @@ def test_pase_header(headers_input, expected):
                 "method": "POST",
                 "no_save": False,
                 "url": URL("https://example.com"),
+                "timeout": cli.TIMEOUT_DEFAULT,
             },
         ),
         (
@@ -81,16 +86,22 @@ def test_pase_header(headers_input, expected):
                 "23",
                 "--auth",
                 "bigetti:password",
+                "--timeout",
+                "3",
             ],
             {
                 "auth": ("bigetti", "password"),
                 "concurrency": 23,
                 "file": pathlib.Path("myfile.csv"),
                 "form_data": False,
-                "header": [("x-foo", "bar"), ("fizz", "buzz")],
+                "header": [
+                    ("x-foo", "bar"),
+                    ("fizz", "buzz"),
+                ],
                 "method": "POST",
                 "no_save": False,
                 "url": URL("https://example.com"),
+                "timeout": 3,
             },
         ),
     ],

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -23,6 +23,8 @@ def test_normalize_ulr(url, expected):
         # this probably invalid auth but not responsiblity of _resolve_auth
         ("foo bar bazz", ("foo", "bar bazz")),
         ("fizz", ("fizz", "fake_input")),
+        # also not valid
+        ("", ("", "fake_input")),
     ],
 )
 def test_resolve_auth(monkeypatch, auth_input, expected):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -23,15 +23,10 @@ def test_normalize_ulr(url, expected):
     "auth_input,expected",
     [
         ("foo:bar", ("foo", "bar")),
-        # ("foo=bar", ("foo", "bar")),
+        ("foo=bar", ("foo", "bar")),
         ("fizz", ("fizz", "fake_input")),
         ("nopassword:", ("nopassword", "")),
-        # ("nopassword=", ("nopassword", "")),
-        # ensure base64 `=` padding is not stripped from user string
-        (
-            f"{base64.standard_b64encode(b'b64-nopassword').decode('utf-8')}:",
-            (base64.standard_b64encode(b"b64-nopassword").decode("utf-8"), ""),
-        ),
+        ("nopassword=", ("nopassword", "")),
         # also not valid
         ("", ("", "fake_input")),
     ],
@@ -43,14 +38,19 @@ def test_resolve_auth(monkeypatch, auth_input, expected):
 
 
 @pytest.mark.parametrize(
-    "headers_input",
+    "headers_input,expected",
     [
-        "foo:bar",
-        "foo=bar",
+        ("foo:bar", ("foo", "bar")),
+        ("foo=bar", ("foo", "bar")),
+        (
+            # ensure base64 padding is not removed
+            f"foo={base64.standard_b64encode(b'bar64').decode('utf-8')}",
+            ("foo", base64.standard_b64encode(b"bar64").decode("utf-8")),
+        ),
     ],
 )
-def test_pase_header(headers_input):
-    assert ("foo", "bar") == cli._parse_header(headers_input)
+def test_pase_header(headers_input, expected):
+    assert expected == cli._parse_header(headers_input)
 
 
 @pytest.mark.parametrize(

--- a/tests/test_csv2http.py
+++ b/tests/test_csv2http.py
@@ -2,4 +2,4 @@ from csv2http import __version__
 
 
 def test_version():
-    assert __version__ == "0.0.2a1"
+    assert __version__ == "0.0.3a"

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,3 +1,5 @@
+import ast
+
 import httpx
 import pytest
 from respx import MockResponse
@@ -19,8 +21,14 @@ from csv2http import utils
 )
 def test_summarize_responses(responses):
     summary = utils.summarize_responses(responses)
-    print(summary)
     assert summary
+
+    _, status_codes = summary.split(" - ")
+    status_codes_dict = ast.literal_eval(status_codes)
+    print(status_codes_dict)
+
+    for r in responses:
+        assert getattr(r, "status_code", r.__class__.__name__) in status_codes_dict
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### Add additional CLI arguments
`--headers` `-H` for setting 1 or more request headers
`--auth` `-a` for setting Basic Auth credentials
`--timeout` `-t` for setting connection timeout settings

### Other changes
* better tests
* `cli.py` refactoring