### PR TITLE
Python 3.7 support

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -65,7 +65,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: [3.9, '3.10']
+        python-version: [3.8, 3.9, '3.10']
 
     runs-on: ${{ matrix.os }}
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -65,7 +65,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: [3.8, 3.9, '3.10']
+        python-version: [3.6, 3.7, 3.8, 3.9, '3.10']
 
     runs-on: ${{ matrix.os }}
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -65,7 +65,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: [3.6, 3.7, 3.8, 3.9, '3.10']
+        python-version: [3.7, 3.8, 3.9, '3.10']
 
     runs-on: ${{ matrix.os }}
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Check CLI usage
 ❯ csv2http --help
 usage: csv2http [-h] [-c CONCURRENCY] [--method {POST,PATCH,PUT}] [-a AUTH] [-H [HEADER ...]] [-d] [-n] [-t TIMEOUT] file url
 
-HTTP request for every row of a CSV file - v0.0.3a
+HTTP request for every row of a CSV file - v0.0.3a1
 
 positional arguments:
   file                  payload csv file

--- a/csv2http/_version.py
+++ b/csv2http/_version.py
@@ -1,2 +1,2 @@
 """_version"""
-__version__ = "0.0.3a"
+__version__ = "0.0.3a1"

--- a/csv2http/cli.py
+++ b/csv2http/cli.py
@@ -10,7 +10,7 @@ from typing import NamedTuple, Optional, Tuple, Union
 try:
     from typing import Literal
 except ImportError:
-    from typing_extensions import Literal
+    from typing_extensions import Literal  # type: ignore
 
 from httpx import URL, Headers
 

--- a/csv2http/cli.py
+++ b/csv2http/cli.py
@@ -5,7 +5,12 @@ cli.py
 import argparse
 import pathlib
 import re
-from typing import Literal, NamedTuple, Optional, Tuple, Union
+from typing import NamedTuple, Optional, Tuple, Union
+
+try:
+    from typing import Literal
+except ImportError:
+    from typing_extensions import Literal
 
 from httpx import URL, Headers
 

--- a/csv2http/cli.py
+++ b/csv2http/cli.py
@@ -5,7 +5,7 @@ cli.py
 import argparse
 import pathlib
 import re
-from typing import Literal, NamedTuple, Optional, Union
+from typing import Literal, NamedTuple, Optional, Tuple, Union
 
 from httpx import URL, Headers
 
@@ -30,7 +30,7 @@ def _normalize_url(value: Union[str, URL]) -> URL:
     return url
 
 
-def _resolve_auth(value: str) -> Union[tuple[str, str], tuple[None, None]]:
+def _resolve_auth(value: str) -> Union[Tuple[str, str], Tuple[None, None]]:
     """
     Parse username & password. Prompt for password if not provided.
     """
@@ -39,7 +39,7 @@ def _resolve_auth(value: str) -> Union[tuple[str, str], tuple[None, None]]:
     return username, password
 
 
-def _parse_header(value: str) -> tuple[str, str]:
+def _parse_header(value: str) -> Tuple[str, str]:
     """Splits string on `:` or `=` and returns a tuple of key, value."""
     key, value = re.split(_SPLIT_REGEX, value, maxsplit=1)
     return key, value
@@ -113,7 +113,7 @@ class Args(NamedTuple):
     url: Union[URL, str]
     concurrency: int
     method: Literal["POST", "PATCH", "PUT"]
-    auth: Optional[tuple[str, str]] = None
+    auth: Optional[Tuple[str, str]] = None
     headers: Optional[Headers] = None
     form_data: bool = False
     save_log: bool = True

--- a/csv2http/core.py
+++ b/csv2http/core.py
@@ -87,7 +87,7 @@ async def parrelelize_requests(
     return responses
 
 
-async def execute(args: cli.Args) -> int:
+async def execute(args: cli.Args, **client_kwargs) -> int:
     """Make http requests given a CSV file and user arguments."""
     file_input = pathlib.Path(args.file)
     assert file_input.exists(), f"could not find {file_input.absolute()}"
@@ -98,7 +98,7 @@ async def execute(args: cli.Args) -> int:
     log_file = _add_timestamp_and_suffix(file_input, "log")
 
     async with httpx.AsyncClient(
-        auth=args.auth, headers=args.headers, timeout=args.timeout
+        auth=args.auth, headers=args.headers, timeout=args.timeout, **client_kwargs
     ) as client_session:
 
         print(f" {args.method} {args.url}")

--- a/csv2http/core.py
+++ b/csv2http/core.py
@@ -5,7 +5,12 @@ core.py
 import asyncio
 import logging
 import pathlib
-from typing import Generator, Iterable, List, Literal, Union
+from typing import Generator, Iterable, List, Union
+
+try:
+    from typing import Literal
+except ImportError:
+    from typing_extensions import Literal
 
 import httpx
 

--- a/csv2http/core.py
+++ b/csv2http/core.py
@@ -5,7 +5,7 @@ core.py
 import asyncio
 import logging
 import pathlib
-from typing import Generator, Iterable, Literal, Union
+from typing import Generator, Iterable, List, Literal, Union
 
 import httpx
 
@@ -25,7 +25,7 @@ LOGGER = logging.getLogger(__file__)
 
 def chunker(
     input_iterator: Iterable[dict], chunk_size: int = PAGE_SIZE_DEFAULT
-) -> Generator[list[dict], None, None]:
+) -> Generator[List[dict], None, None]:
     """Works through an iterator and returns batches based on `chunk_size`."""
     chunk = []
     for data in input_iterator:
@@ -47,9 +47,9 @@ async def parrelelize_requests(
     method: Methods,
     path: Union[str, httpx.URL],
     # TODO: create type for request_kwargs
-    request_kwarg_list: list[dict],
+    request_kwarg_list: List[dict],
     client_session: httpx.AsyncClient,
-) -> list[httpx.Response]:
+) -> List[httpx.Response]:
     """
     Parreleize multiple HTTP requests with asyncio.gather.
 
@@ -67,7 +67,7 @@ async def parrelelize_requests(
 
     Returns
     -------
-    list[httpx.Response]
+    List[httpx.Response]
         List of HTTP response objects.
     """
 

--- a/csv2http/core.py
+++ b/csv2http/core.py
@@ -10,7 +10,7 @@ from typing import Generator, Iterable, List, Union
 try:
     from typing import Literal
 except ImportError:
-    from typing_extensions import Literal
+    from typing_extensions import Literal  # type: ignore
 
 import httpx
 

--- a/csv2http/parser.py
+++ b/csv2http/parser.py
@@ -32,10 +32,7 @@ def csv_payload_generator(
     """
 
     with open(filepath, encoding="utf-8") as file_in:
-        for i, row_dict in enumerate(
-            csv.DictReader(file_in, delimiter=delimiter, **reader_kwargs)
-        ):
-            LOGGER.debug(f"{i=} - {row_dict}")
+        for row_dict in csv.DictReader(file_in, delimiter=delimiter, **reader_kwargs):
             if mutator:
                 row_dict = mutator(row_dict)
             yield row_dict

--- a/csv2http/utils.py
+++ b/csv2http/utils.py
@@ -6,7 +6,7 @@ Homeless utilities.
 import datetime as dt
 import pathlib
 import traceback
-from typing import Counter, Union
+from typing import Counter, List, Union
 
 from httpx import Request, Response
 
@@ -49,7 +49,7 @@ def response_details(response: Response, verbose: bool = False) -> str:
     return result
 
 
-def summarize_responses(responses: list[Response]) -> str:
+def summarize_responses(responses: List[Response]) -> str:
     """Returns count of all response status codes sorted by status code"""
     # TODO: make this pretty, display as table with running tally of previous responses
     counter = Counter(
@@ -81,7 +81,7 @@ def _extract_log(response: Response) -> str:
 
 def append_responses(
     log_path: pathlib.Path,
-    responses: list[Response],
+    responses: List[Response],
 ) -> pathlib.Path:
     """
     Append response results to a file.

--- a/poetry.lock
+++ b/poetry.lock
@@ -510,8 +510,8 @@ python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,>=2.7"
 
 [metadata]
 lock-version = "1.1"
-python-versions = "^3.9"
-content-hash = "615d4684d890a45fdd6a536563e053967b3a20d8c2171660c4cfb1aaafb68359"
+python-versions = "^3.8"
+content-hash = "24b92ae2477aaddf00eb30e0fe051a7b51667f18a2cd894463a05f23c80e6ec2"
 
 [metadata.files]
 anyio = [

--- a/poetry.lock
+++ b/poetry.lock
@@ -9,6 +9,7 @@ python-versions = ">=3.6.2"
 [package.dependencies]
 idna = ">=2.8"
 sniffio = ">=1.1"
+typing-extensions = {version = "*", markers = "python_version < \"3.8\""}
 
 [package.extras]
 doc = ["packaging", "sphinx-rtd-theme", "sphinx-autodoc-typehints (>=1.2.0)"]
@@ -25,6 +26,7 @@ python-versions = ">=3.6.2"
 
 [package.dependencies]
 lazy-object-proxy = ">=1.4.0"
+typed-ast = {version = ">=1.4.0,<2.0", markers = "implementation_name == \"cpython\" and python_version < \"3.8\""}
 typing-extensions = {version = ">=3.10", markers = "python_version < \"3.10\""}
 wrapt = ">=1.11,<2"
 
@@ -64,6 +66,7 @@ mypy-extensions = ">=0.4.3"
 pathspec = ">=0.9.0"
 platformdirs = ">=2"
 tomli = {version = ">=1.1.0", markers = "python_version < \"3.11\""}
+typed-ast = {version = ">=1.4.2", markers = "python_version < \"3.8\" and implementation_name == \"cpython\""}
 typing-extensions = {version = ">=3.10.0.0", markers = "python_version < \"3.10\""}
 
 [package.extras]
@@ -90,6 +93,7 @@ python-versions = ">=3.7"
 
 [package.dependencies]
 colorama = {version = "*", markers = "platform_system == \"Windows\""}
+importlib-metadata = {version = "*", markers = "python_version < \"3.8\""}
 
 [[package]]
 name = "colorama"
@@ -187,6 +191,23 @@ optional = false
 python-versions = ">=3.5"
 
 [[package]]
+name = "importlib-metadata"
+version = "4.11.4"
+description = "Read metadata from Python packages"
+category = "dev"
+optional = false
+python-versions = ">=3.7"
+
+[package.dependencies]
+typing-extensions = {version = ">=3.6.4", markers = "python_version < \"3.8\""}
+zipp = ">=0.5"
+
+[package.extras]
+docs = ["sphinx", "jaraco.packaging (>=9)", "rst.linker (>=1.9)"]
+perf = ["ipython"]
+testing = ["pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-cov", "pytest-enabler (>=1.0.1)", "packaging", "pyfakefs", "flufl.flake8", "pytest-perf (>=0.9.2)", "pytest-black (>=0.3.7)", "pytest-mypy (>=0.9.1)", "importlib-resources (>=1.3)"]
+
+[[package]]
 name = "iniconfig"
 version = "1.1.1"
 description = "iniconfig: brain-dead simple config-ini parsing"
@@ -243,6 +264,7 @@ python-versions = ">=3.6"
 [package.dependencies]
 mypy-extensions = ">=0.4.3"
 tomli = {version = ">=1.1.0", markers = "python_version < \"3.11\""}
+typed-ast = {version = ">=1.4.0,<2", markers = "python_version < \"3.8\""}
 typing-extensions = ">=3.10"
 
 [package.extras]
@@ -296,6 +318,9 @@ description = "plugin and hook calling mechanisms for python"
 category = "dev"
 optional = false
 python-versions = ">=3.6"
+
+[package.dependencies]
+importlib-metadata = {version = ">=0.12", markers = "python_version < \"3.8\""}
 
 [package.extras]
 dev = ["pre-commit", "tox"]
@@ -363,6 +388,7 @@ python-versions = ">=3.7"
 atomicwrites = {version = ">=1.0", markers = "sys_platform == \"win32\""}
 attrs = ">=19.2.0"
 colorama = {version = "*", markers = "sys_platform == \"win32\""}
+importlib-metadata = {version = ">=0.12", markers = "python_version < \"3.8\""}
 iniconfig = "*"
 packaging = "*"
 pluggy = ">=0.12,<2.0"
@@ -382,6 +408,7 @@ python-versions = ">=3.7"
 
 [package.dependencies]
 pytest = ">=6.1.0"
+typing-extensions = {version = ">=3.7.2", markers = "python_version < \"3.8\""}
 
 [package.extras]
 testing = ["coverage (==6.2)", "hypothesis (>=5.7.1)", "flaky (>=3.5.0)", "mypy (==0.931)", "pytest-trio (>=0.7.0)"]
@@ -485,6 +512,14 @@ optional = false
 python-versions = ">=3.6,<4.0"
 
 [[package]]
+name = "typed-ast"
+version = "1.5.4"
+description = "a fork of Python 2 and 3 ast modules with type comment support"
+category = "dev"
+optional = false
+python-versions = ">=3.6"
+
+[[package]]
 name = "types-invoke"
 version = "1.6.8"
 description = "Typing stubs for invoke"
@@ -496,7 +531,7 @@ python-versions = "*"
 name = "typing-extensions"
 version = "4.2.0"
 description = "Backported and Experimental Type Hints for Python 3.7+"
-category = "dev"
+category = "main"
 optional = false
 python-versions = ">=3.7"
 
@@ -508,10 +543,22 @@ category = "dev"
 optional = false
 python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,>=2.7"
 
+[[package]]
+name = "zipp"
+version = "3.8.0"
+description = "Backport of pathlib-compatible object wrapper for zip files"
+category = "dev"
+optional = false
+python-versions = ">=3.7"
+
+[package.extras]
+docs = ["sphinx", "jaraco.packaging (>=9)", "rst.linker (>=1.9)"]
+testing = ["pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-cov", "pytest-enabler (>=1.0.1)", "jaraco.itertools", "func-timeout", "pytest-black (>=0.3.7)", "pytest-mypy (>=0.9.1)"]
+
 [metadata]
 lock-version = "1.1"
-python-versions = "^3.8"
-content-hash = "24b92ae2477aaddf00eb30e0fe051a7b51667f18a2cd894463a05f23c80e6ec2"
+python-versions = "^3.7.2"
+content-hash = "a49cc43e89ed84b65d4a79321c5fc1f15d0cf811486e54bd5c7d69a9e5837ef3"
 
 [metadata.files]
 anyio = [
@@ -632,6 +679,10 @@ icdiff = [
 idna = [
     {file = "idna-3.3-py3-none-any.whl", hash = "sha256:84d9dd047ffa80596e0f246e2eab0b391788b0503584e8945f2368256d2735ff"},
     {file = "idna-3.3.tar.gz", hash = "sha256:9d643ff0a55b762d5cdb124b8eaa99c66322e2157b69160bc32796e824360e6d"},
+]
+importlib-metadata = [
+    {file = "importlib_metadata-4.11.4-py3-none-any.whl", hash = "sha256:c58c8eb8a762858f49e18436ff552e83914778e50e9d2f1660535ffb364552ec"},
+    {file = "importlib_metadata-4.11.4.tar.gz", hash = "sha256:5d26852efe48c0a32b0509ffbc583fda1a2266545a78d104a6f4aff3db17d700"},
 ]
 iniconfig = [
     {file = "iniconfig-1.1.1-py2.py3-none-any.whl", hash = "sha256:011e24c64b7f47f6ebd835bb12a743f2fbe9a26d4cecaa7f53bc4f35ee9da8b3"},
@@ -791,6 +842,32 @@ tomlkit = [
     {file = "tomlkit-0.11.0-py3-none-any.whl", hash = "sha256:0f4050db66fd445b885778900ce4dd9aea8c90c4721141fde0d6ade893820ef1"},
     {file = "tomlkit-0.11.0.tar.gz", hash = "sha256:71ceb10c0eefd8b8f11fe34e8a51ad07812cb1dc3de23247425fbc9ddc47b9dd"},
 ]
+typed-ast = [
+    {file = "typed_ast-1.5.4-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:669dd0c4167f6f2cd9f57041e03c3c2ebf9063d0757dc89f79ba1daa2bfca9d4"},
+    {file = "typed_ast-1.5.4-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:211260621ab1cd7324e0798d6be953d00b74e0428382991adfddb352252f1d62"},
+    {file = "typed_ast-1.5.4-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:267e3f78697a6c00c689c03db4876dd1efdfea2f251a5ad6555e82a26847b4ac"},
+    {file = "typed_ast-1.5.4-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:c542eeda69212fa10a7ada75e668876fdec5f856cd3d06829e6aa64ad17c8dfe"},
+    {file = "typed_ast-1.5.4-cp310-cp310-win_amd64.whl", hash = "sha256:a9916d2bb8865f973824fb47436fa45e1ebf2efd920f2b9f99342cb7fab93f72"},
+    {file = "typed_ast-1.5.4-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:79b1e0869db7c830ba6a981d58711c88b6677506e648496b1f64ac7d15633aec"},
+    {file = "typed_ast-1.5.4-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a94d55d142c9265f4ea46fab70977a1944ecae359ae867397757d836ea5a3f47"},
+    {file = "typed_ast-1.5.4-cp36-cp36m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:183afdf0ec5b1b211724dfef3d2cad2d767cbefac291f24d69b00546c1837fb6"},
+    {file = "typed_ast-1.5.4-cp36-cp36m-win_amd64.whl", hash = "sha256:639c5f0b21776605dd6c9dbe592d5228f021404dafd377e2b7ac046b0349b1a1"},
+    {file = "typed_ast-1.5.4-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:cf4afcfac006ece570e32d6fa90ab74a17245b83dfd6655a6f68568098345ff6"},
+    {file = "typed_ast-1.5.4-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ed855bbe3eb3715fca349c80174cfcfd699c2f9de574d40527b8429acae23a66"},
+    {file = "typed_ast-1.5.4-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:6778e1b2f81dfc7bc58e4b259363b83d2e509a65198e85d5700dfae4c6c8ff1c"},
+    {file = "typed_ast-1.5.4-cp37-cp37m-win_amd64.whl", hash = "sha256:0261195c2062caf107831e92a76764c81227dae162c4f75192c0d489faf751a2"},
+    {file = "typed_ast-1.5.4-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:2efae9db7a8c05ad5547d522e7dbe62c83d838d3906a3716d1478b6c1d61388d"},
+    {file = "typed_ast-1.5.4-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:7d5d014b7daa8b0bf2eaef684295acae12b036d79f54178b92a2b6a56f92278f"},
+    {file = "typed_ast-1.5.4-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:370788a63915e82fd6f212865a596a0fefcbb7d408bbbb13dea723d971ed8bdc"},
+    {file = "typed_ast-1.5.4-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:4e964b4ff86550a7a7d56345c7864b18f403f5bd7380edf44a3c1fb4ee7ac6c6"},
+    {file = "typed_ast-1.5.4-cp38-cp38-win_amd64.whl", hash = "sha256:683407d92dc953c8a7347119596f0b0e6c55eb98ebebd9b23437501b28dcbb8e"},
+    {file = "typed_ast-1.5.4-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:4879da6c9b73443f97e731b617184a596ac1235fe91f98d279a7af36c796da35"},
+    {file = "typed_ast-1.5.4-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:3e123d878ba170397916557d31c8f589951e353cc95fb7f24f6bb69adc1a8a97"},
+    {file = "typed_ast-1.5.4-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ebd9d7f80ccf7a82ac5f88c521115cc55d84e35bf8b446fcd7836eb6b98929a3"},
+    {file = "typed_ast-1.5.4-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:98f80dee3c03455e92796b58b98ff6ca0b2a6f652120c263efdba4d6c5e58f72"},
+    {file = "typed_ast-1.5.4-cp39-cp39-win_amd64.whl", hash = "sha256:0fdbcf2fef0ca421a3f5912555804296f0b0960f0418c440f5d6d3abb549f3e1"},
+    {file = "typed_ast-1.5.4.tar.gz", hash = "sha256:39e21ceb7388e4bb37f4c679d72707ed46c2fbf2a5609b8b8ebc4b067d977df2"},
+]
 types-invoke = [
     {file = "types-invoke-1.6.8.tar.gz", hash = "sha256:aee549ffcca37e778d332a299ebcd969c5d2a98ad4dce3a547ce1981ec6493a9"},
     {file = "types_invoke-1.6.8-py3-none-any.whl", hash = "sha256:68f0b0915f7d3708f87029b423bd335401da21234968fb4af7f7d8db4f87a022"},
@@ -864,4 +941,8 @@ wrapt = [
     {file = "wrapt-1.14.1-cp39-cp39-win32.whl", hash = "sha256:dee0ce50c6a2dd9056c20db781e9c1cfd33e77d2d569f5d1d9321c641bb903d5"},
     {file = "wrapt-1.14.1-cp39-cp39-win_amd64.whl", hash = "sha256:dee60e1de1898bde3b238f18340eec6148986da0455d8ba7848d50470a7a32fb"},
     {file = "wrapt-1.14.1.tar.gz", hash = "sha256:380a85cf89e0e69b7cfbe2ea9f765f004ff419f34194018a6827ac0e3edfed4d"},
+]
+zipp = [
+    {file = "zipp-3.8.0-py3-none-any.whl", hash = "sha256:c4f6e5bbf48e74f7a38e7cc5b0480ff42b0ae5178957d564d18932525d5cf099"},
+    {file = "zipp-3.8.0.tar.gz", hash = "sha256:56bf8aadb83c24db6c4b577e13de374ccfb67da2078beba1d037c17980bf43ad"},
 ]

--- a/poetry.lock
+++ b/poetry.lock
@@ -558,7 +558,7 @@ testing = ["pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.7.2"
-content-hash = "a49cc43e89ed84b65d4a79321c5fc1f15d0cf811486e54bd5c7d69a9e5837ef3"
+content-hash = "e258d4ecd7527d5f82d3e1b0b770eac91ed24ca83420c51a37785f0d0f81a546"
 
 [metadata.files]
 anyio = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,7 @@ f2http = "csv2http.core:main"
 [tool.poetry.dependencies]
 python = "^3.7.2"
 httpx = "^0.23.0"
+typing-extensions = { version = "^4.2.0", python = "~3.7"}
 
 [tool.poetry.dev-dependencies]
 respx = "^0.19.2"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ csv2http = "csv2http.core:main"
 f2http = "csv2http.core:main"
 
 [tool.poetry.dependencies]
-python = "^3.6.2"
+python = "^3.7.2"
 httpx = "^0.23.0"
 
 [tool.poetry.dev-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "csv2http"
-version = "0.0.3a"
+version = "0.0.3a1"
 description = "Make http requests based on a CSV input file"
 authors = ["Gabriel Gore <gabriel59kg@gmail.com>"]
 license = "MIT License"
@@ -26,7 +26,7 @@ csv2http = "csv2http.core:main"
 f2http = "csv2http.core:main"
 
 [tool.poetry.dependencies]
-python = "^3.9"
+python = "^3.8"
 httpx = "^0.23.0"
 
 [tool.poetry.dev-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ csv2http = "csv2http.core:main"
 f2http = "csv2http.core:main"
 
 [tool.poetry.dependencies]
-python = "^3.8"
+python = "^3.6.2"
 httpx = "^0.23.0"
 
 [tool.poetry.dev-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,8 +11,10 @@ license = "MIT License"
 readme = "README.md"
 repository = "https://github.com/kilo59/csv2http"
 homepage = "https://github.com/kilo59/csv2http"
-keywords = ["http", "csv", "cli", "remediation"]
+keywords = ["http", "csv", "cli", "remediation", "async"]
 classifiers = [
+    "Programming Language :: Python :: 3.8",
+    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "License :: OSI Approved :: MIT License",
     "Development Status :: 2 - Pre-Alpha",

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -14,11 +14,11 @@ def test_chunker_chunk_size():
     chunker_gen = core.chunker(input_iterator, chunk_size=chunk_size)
 
     first_result = next(chunker_gen)
-    print(f"{first_result=}")
+    print(f"first_result={first_result}")
     assert len(first_result) == chunk_size
 
     last_result = next(chunker_gen)
-    print(f"{last_result=}")
+    print(f"last_result={last_result}")
     assert len(last_result) == len(input_iterator) - chunk_size
 
 

--- a/tests/test_csv2http.py
+++ b/tests/test_csv2http.py
@@ -2,4 +2,4 @@ from csv2http import __version__
 
 
 def test_version():
-    assert __version__ == "0.0.3a"
+    assert __version__ == "0.0.3a1"


### PR DESCRIPTION
Update typing and f-string usage to make python 3.7, 3.8 compatible

`core.execute()` accepts and passes through `httpx.AsyncClient` keyword arguments. Useful if using `csv2http` within a script. 